### PR TITLE
Adding --no-libar option in the build script

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Emscripten port of [ARToolKit](https://github.com/artoolkitx/artoolkit5) to JavaScript.
 
-## MArkers Types
+## Markers Types
 
 JSARToolKit5 support these types of markers:
 - Square pictorial markers
@@ -62,10 +62,11 @@ See examples/simple_image_wasm.html for details.
 3. `npm install`
 4. From inside jsartoolkit5 directory run `docker run -dit --name emscripten -v $(pwd):/src trzeci/emscripten-slim:latest bash` to download and start the container, in preparation for the build
 5. `docker exec emscripten npm run build-local` to build JS version of artoolkit5
-6. `docker stop emscripten` to stop the container after the build, if needed
-7. `docker rm emscripten` to remove the container
-8. `docker rmi trzeci/emscripten-slim:latest` to remove the Docker image, if you don't need it anymore
-9. The build artifacts will appear in `/build`. There's a build with debug symbols in `artoolkit.debug.js` file and the optimized build with bundled JS API in `artoolkit.min.js`; also, a WebAssembly build artoolkit_wasm.js and artoolkit_wasm.wasm
+6. `docker exec emscripten npm run build-local-no-libar` to build JS version of artoolkit5 without rebuilding libar.bc
+7. `docker stop emscripten` to stop the container after the build, if needed
+8. `docker rm emscripten` to remove the container
+9. `docker rmi trzeci/emscripten-slim:latest` to remove the Docker image, if you don't need it anymore
+10. The build artifacts will appear in `/build`. There's a build with debug symbols in `artoolkit.debug.js` file and the optimized build with bundled JS API in `artoolkit.min.js`; also, a WebAssembly build artoolkit_wasm.js and artoolkit_wasm.wasm
 
 ### ⚠️ Not recommended ⚠️ : Build local with manual emscripten setup
 
@@ -89,7 +90,7 @@ jsartoolkit5 aim is to create a Javascript version of artoolkit5. First, you nee
   3. Run `npm install`
   4. Run `npm run build-local`
 
-During development, you can run ```npm run watch```, it will rebuild the library everytime you change ```./js/``` directory.
+During development, you can run ```npm run watch```, it will rebuild the library everytime you change ```./js/``` directory. You can also run the script with the option ```npm run build-local-no-libar``` if you have already build libar.bc and you don't want to rebuild.
 
 4. The built ASM.js files are in `/build`. There's a build with debug symbols in `artoolkit.debug.js` and the optimized build with bundled JS API in `artoolkit.min.js`.
 

--- a/README.md
+++ b/README.md
@@ -86,13 +86,13 @@ To prevent issues with Emscripten setup and to not have to maintain several buil
 
 jsartoolkit5 aim is to create a Javascript version of artoolkit5\. First, you need the artoolkit5 repository on your machine:
 
-1. Clone ARToolKit5 project to get the latest source files. From within jsartoolkit5 directory do `git submodule update --init`. If you already cloned ARToolKit5 to a different directory you can:
+2. Clone ARToolKit5 project to get the latest source files. From within jsartoolkit5 directory do `git submodule update --init`. If you already cloned ARToolKit5 to a different directory you can:
 
   - create a link in the `jsartoolkit5/emscripten/` directory that points to ARToolKit5 (`jsartoolkit5/emscripten/artoolkit5`)
   - or, set the `ARTOOLKIT5_ROOT` environment variable to point to your ARToolKit5 clone
   - or, change the `tools/makem.js` file to point to your artoolkit5 clone (line 20)
 
-2. Building
+3. Building
 
   1. Make sure `EMSCRIPTEN` env variable is set (e.g. `EMSCRIPTEN=/usr/lib/emsdk_portable/emscripten/master/ node tools/makem.js`
   2. Run `npm install`
@@ -100,7 +100,7 @@ jsartoolkit5 aim is to create a Javascript version of artoolkit5\. First, you ne
 
 During development, you can run `npm run watch`, it will rebuild the library everytime you change `./js/` directory. You can also run the script with the option `npm run build-local-no-libar` if you have already build libar.bc and you don't want to rebuild.
 
-1. The built ASM.js files are in `/build`. There's a build with debug symbols in `artoolkit.debug.js` and the optimized build with bundled JS API in `artoolkit.min.js`.
+4. The built ASM.js files are in `/build`. There's a build with debug symbols in `artoolkit.debug.js` and the optimized build with bundled JS API in `artoolkit.min.js`.
 
 ## ARToolKit JS API
 

--- a/README.md
+++ b/README.md
@@ -5,17 +5,19 @@ Emscripten port of [ARToolKit](https://github.com/artoolkitx/artoolkit5) to Java
 ## Markers Types
 
 JSARToolKit5 support these types of markers:
+
 - Square pictorial markers
 - Square barcode markers
 - Multi square markers set
 - NFT (natural feature tracking) markers
 
----
+--------------------------------------------------------------------------------
+
 **NOTE:**
 
 When writing JavaScript and making changes be aware that the emscripten uglifier does not support the ES6 syntax.
 
----
+--------------------------------------------------------------------------------
 
 ## Project Structure
 
@@ -24,31 +26,35 @@ When writing JavaScript and making changes be aware that the emscripten uglifier
 - `emscripten/` (source code for ARToolKit.js)
 - `examples/` (demos and examples using ARToolKit.js)
 - `js/` (compiled versions of ARToolKit.js with Three.js helper api)
+- `tests/` (tests for compiled versions of ARToolKit.js)
 - `tools/` (build scripts for building ARToolKit.js)
 
 ## WebAssembly
 
-JSARToolKit5 supports WebAssembly. The libary builds two WebAssembly artifacts during the build process. These are ```build/artoolkit_wasm.js``` and ```build/artoolkit_wasm.wasm```. To use those, include the artoolkit_wasm.js into your html page and define ```var artoolkit_wasm_url = '<<PATH TO>>/artoolkit_wasm.wasm';``` before loading the artoolkit_wasm.js file, like this:
+JSARToolKit5 supports WebAssembly. The libary builds two WebAssembly artifacts during the build process. These are `build/artoolkit_wasm.js` and `build/artoolkit_wasm.wasm`. To use those, include the artoolkit_wasm.js into your html page and define `var artoolkit_wasm_url = '<<PATH TO>>/artoolkit_wasm.wasm';` before loading the artoolkit_wasm.js file, like this:
 
-```js
+```javascript
 <script type='text/javascript'>
       var artoolkit_wasm_url = '../build/artoolkit_wasm.wasm';
 </script>
 <script src="../build/artoolkit_wasm.js"></script>
 ```
+
 As loading the WebAssembly artifact is done asynchronously, there is a callback that is called when everything is ready.
 
-```js
+```javascript
 window.addEventListener('artoolkit-loaded', () => {
     //do artoolkit stuff here
 });
 ```
+
 See examples/simple_image_wasm.html for details.
 
 ## Clone the repository
 
 1. Clone this repository
 2. Clone ARToolKit5 project to get the latest source files. From within jsartoolkit5 directory do `git submodule update --init`. If you already cloned ARToolKit5 to a different directory you can:
+
   - create a link in the `jsartoolkit5/emscripten/` directory that points to ARToolKit5 (`jsartoolkit5/emscripten/artoolkit5`) (Linux and macOS only)
   - or, set the `ARTOOLKIT5_ROOT` environment variable to point to your ARToolKit5 clone
   - or, change the `tools/makem.js` file to point to your artoolkit5 clone (line 20)
@@ -70,33 +76,35 @@ See examples/simple_image_wasm.html for details.
 
 ### ⚠️ Not recommended ⚠️ : Build local with manual emscripten setup
 
-To prevent issues with Emscripten setup and to not have to maintain several build environments (macOS, Windows, Linux) we only maintain the **Build using Docker**. Following are the instructions of the last know build on Linux which we verified are working. **Use at own risk.**
-** Not working on macOS!**
+To prevent issues with Emscripten setup and to not have to maintain several build environments (macOS, Windows, Linux) we only maintain the **Build using Docker**. Following are the instructions of the last know build on Linux which we verified are working. **Use at own risk.** **Not working on macOS!**
 
 1. Install build tools
-  1. Install node.js (https://nodejs.org/en/)
-  2. Install python2 (https://www.python.org/downloads/)
-  3. Install emscripten (https://emscripten.org/docs/getting_started/downloads.html#download-and-install)
-     We used emscripten version **1.39.5-fastcomp** ~~1.38.44-fastcomp~~
 
-jsartoolkit5 aim is to create a Javascript version of artoolkit5. First, you need the artoolkit5 repository on your machine:
-2. Clone ARToolKit5 project to get the latest source files. From within jsartoolkit5 directory do `git submodule update --init`. If you already cloned ARToolKit5 to a different directory you can:
+  1. Install node.js (<https://nodejs.org/en/>)
+  2. Install python2 (<https://www.python.org/downloads/>)
+  3. Install emscripten (<https://emscripten.org/docs/getting_started/downloads.html#download-and-install>) We used emscripten version **1.39.5-fastcomp** ~~1.38.44-fastcomp~~
+
+jsartoolkit5 aim is to create a Javascript version of artoolkit5\. First, you need the artoolkit5 repository on your machine:
+
+1. Clone ARToolKit5 project to get the latest source files. From within jsartoolkit5 directory do `git submodule update --init`. If you already cloned ARToolKit5 to a different directory you can:
+
   - create a link in the `jsartoolkit5/emscripten/` directory that points to ARToolKit5 (`jsartoolkit5/emscripten/artoolkit5`)
   - or, set the `ARTOOLKIT5_ROOT` environment variable to point to your ARToolKit5 clone
   - or, change the `tools/makem.js` file to point to your artoolkit5 clone (line 20)
 
-3. Building
+2. Building
+
   1. Make sure `EMSCRIPTEN` env variable is set (e.g. `EMSCRIPTEN=/usr/lib/emsdk_portable/emscripten/master/ node tools/makem.js`
-  3. Run `npm install`
-  4. Run `npm run build-local`
+  2. Run `npm install`
+  3. Run `npm run build-local`
 
-During development, you can run ```npm run watch```, it will rebuild the library everytime you change ```./js/``` directory. You can also run the script with the option ```npm run build-local-no-libar``` if you have already build libar.bc and you don't want to rebuild.
+During development, you can run `npm run watch`, it will rebuild the library everytime you change `./js/` directory. You can also run the script with the option `npm run build-local-no-libar` if you have already build libar.bc and you don't want to rebuild.
 
-4. The built ASM.js files are in `/build`. There's a build with debug symbols in `artoolkit.debug.js` and the optimized build with bundled JS API in `artoolkit.min.js`.
+1. The built ASM.js files are in `/build`. There's a build with debug symbols in `artoolkit.debug.js` and the optimized build with bundled JS API in `artoolkit.min.js`.
 
 ## ARToolKit JS API
 
-```js
+```javascript
 <script src="../build/artoolkit.min.js">
 // include optimized ASM.js build and JS API
 </script>
@@ -104,7 +112,7 @@ During development, you can run ```npm run watch```, it will rebuild the library
 
 ## ARToolKit JS debug build
 
-```js
+```javascript
 <script async src="../build/artoolkit.debug.js">
 // - include debug build
 </script>
@@ -115,7 +123,7 @@ During development, you can run ```npm run watch```, it will rebuild the library
 
 ## ARToolKit Three.js helper API
 
-```js
+```javascript
 <script src="../build/artoolkit.min.js">
 // - include optimized ASM.js build and JS API
 </script>
@@ -150,7 +158,7 @@ The basic operation goes like this:
 
 ### Basic example with an image source and a pattern marker ( hiro )
 
-```js
+```javascript
 <script src="../build/artoolkit.min.js"></script>
 <script>
   var param = new ARCameraParam();
@@ -189,8 +197,7 @@ The basic operation goes like this:
 
 In the code below a summarized example:
 
-
-```js
+```javascript
 <div id="container">
     <video id="video"></video>
     <canvas style="position: absolute; left:0; top:0" id="canvas_draw"></canvas>
@@ -228,7 +235,7 @@ if (navigator.mediaDevices && navigator.mediaDevices.getUserMedia) {
 
 ## Constants
 
-*prepend all these constants with `Module.` or `artoolkit.CONSTANTS` to access them*
+_prepend all these constants with `Module.` or `artoolkit.CONSTANTS` to access them_
 
 ```
 - AR_DEBUG_DISABLE

--- a/examples/barcode_threejs.html
+++ b/examples/barcode_threejs.html
@@ -23,7 +23,7 @@ html,body {
 
 <h1>Barcode marker example with Three.js</h1>
 <p>On Chrome on Android, tap the screen to start playing video stream.</p>
-<p>Show <a href="https://github.com/artoolkit/artoolkit5/blob/master/doc/patterns/Matrix%20code%203x3%20(72dpi)/20.png">3x3 marker id 20</a> to camera to display a colorful sphere on top of it. Tap the sphere to rotate it.
+<p>Show <a href="https://github.com/artoolkitx/artoolkit5/blob/master/doc/patterns/Matrix%20code%203x3%20(72dpi)/20.png">3x3 marker id 20</a> to camera to display a colorful sphere on top of it. Tap the sphere to rotate it.
 
 <p>&larr; <a href="index.html">Back to examples</a></p>
 

--- a/examples/index.html
+++ b/examples/index.html
@@ -32,7 +32,7 @@
 				Barcode tracking
 			</a>
 			<p>Uses device camera.
-			<p>Use <a href="https://github.com/artoolkit/artoolkit5/blob/master/doc/patterns/Matrix%20code%203x3%20(72dpi)/20.png">3x3 marker id 20</a>
+			<p>Use <a href="https://github.com/artoolkitx/artoolkit5/blob/master/doc/patterns/Matrix%20code%203x3%20(72dpi)/20.png">3x3 marker id 20</a>
 		</div>
 
 		<div class="example">
@@ -40,7 +40,7 @@
 				Pattern marker tracking
 			</a>
 			<p>Uses device camera.
-			<p>Use <a href="https://github.com/artoolkit/artoolkit5/blob/master/doc/patterns/Hiro%20pattern.pdf">Hiro pattern</a> and <a href="https://github.com/artoolkit/artoolkit5/blob/master/doc/patterns/Kanji%20pattern.pdf">Kanji pattern</a>
+			<p>Use <a href="https://github.com/artoolkitx/artoolkit5/blob/master/doc/patterns/Hiro%20pattern.pdf">Hiro pattern</a> and <a href="https://github.com/artoolkit/artoolkit5/blob/master/doc/patterns/Kanji%20pattern.pdf">Kanji pattern</a>
 		</div>
 
 		<div class="example">
@@ -49,9 +49,9 @@
 			</a>
 			<p>Uses device camera.
 			<p>Use
-			<a href="https://github.com/artoolkit/artoolkit5/blob/master/doc/patterns/Matrix%20code%203x3%20(72dpi)/5.png">3x3 marker id 5</a>,
-			<a href="https://github.com/artoolkit/artoolkit5/blob/master/doc/patterns/Matrix%20code%203x3%20(72dpi)/20.png">3x3 marker id 20</a>,
-			<a href="https://github.com/artoolkit/artoolkit5/blob/master/doc/patterns/Hiro%20pattern.pdf">Hiro pattern</a> and <a href="https://github.com/artoolkit/artoolkit5/blob/master/doc/patterns/Kanji%20pattern.pdf">Kanji pattern</a>
+			<a href="https://github.com/artoolkitx/artoolkit5/blob/master/doc/patterns/Matrix%20code%203x3%20(72dpi)/5.png">3x3 marker id 5</a>,
+			<a href="https://github.com/artoolkitx/artoolkit5/blob/master/doc/patterns/Matrix%20code%203x3%20(72dpi)/20.png">3x3 marker id 20</a>,
+			<a href="https://github.com/artoolkitx/artoolkit5/blob/master/doc/patterns/Hiro%20pattern.pdf">Hiro pattern</a> and <a href="https://github.com/artoolkit/artoolkit5/blob/master/doc/patterns/Kanji%20pattern.pdf">Kanji pattern</a>
 		</div>
 
 		<div class="example">
@@ -59,7 +59,7 @@
 				Barcode multimarker tracking
 			</a>
 			<p>Uses device camera.
-			<p>Use <a href="https://github.com/artoolkit/artoolkit5/blob/master/doc/patterns/Multi%20pattern%204x3%20(A4).pdf">Multi pattern 4x3</a>
+			<p>Use <a href="https://github.com/artoolkitx/artoolkit5/blob/master/doc/patterns/Multi%20pattern%204x3%20(A4).pdf">Multi pattern 4x3</a>
 		</div>
 
 		<div class="example">
@@ -67,7 +67,7 @@
 				Pattern multimarker tracking
 			</a>
 			<p>Uses device camera.
-			<p>Use <a href="https://github.com/artoolkit/artoolkit5/blob/master/doc/patterns/Multi%20pattern%20(template%2C%20A4).pdf">Multi pattern (template)</a>
+			<p>Use <a href="https://github.com/artoolkitx/artoolkit5/blob/master/doc/patterns/Multi%20pattern%20(template%2C%20A4).pdf">Multi pattern (template)</a>
 		</div>
 
 		<div class="example">
@@ -146,7 +146,7 @@
 				nft with threejs and Wasm
 			</a>
 			<p>Using NFT with three.js and Wasm (and no webworker)
-			<p>Use this <a href="https://github.com/artoolkit/artoolkit5/blob/master/doc/Marker%20images/pinball.jpg">Pinball image</a>
+			<p>Use this <a href="https://github.com/artoolkitx/artoolkit5/blob/master/doc/Marker%20images/pinball.jpg">Pinball image</a>
 				as marker.
 		</div>
 

--- a/examples/index.html
+++ b/examples/index.html
@@ -40,7 +40,7 @@
 				Pattern marker tracking
 			</a>
 			<p>Uses device camera.
-			<p>Use <a href="https://github.com/artoolkitx/artoolkit5/blob/master/doc/patterns/Hiro%20pattern.pdf">Hiro pattern</a> and <a href="https://github.com/artoolkit/artoolkit5/blob/master/doc/patterns/Kanji%20pattern.pdf">Kanji pattern</a>
+			<p>Use <a href="https://github.com/artoolkitx/artoolkit5/blob/master/doc/patterns/Hiro%20pattern.pdf">Hiro pattern</a> and <a href="https://github.com/artoolkitx/artoolkit5/blob/master/doc/patterns/Kanji%20pattern.pdf">Kanji pattern</a>
 		</div>
 
 		<div class="example">
@@ -51,7 +51,7 @@
 			<p>Use
 			<a href="https://github.com/artoolkitx/artoolkit5/blob/master/doc/patterns/Matrix%20code%203x3%20(72dpi)/5.png">3x3 marker id 5</a>,
 			<a href="https://github.com/artoolkitx/artoolkit5/blob/master/doc/patterns/Matrix%20code%203x3%20(72dpi)/20.png">3x3 marker id 20</a>,
-			<a href="https://github.com/artoolkitx/artoolkit5/blob/master/doc/patterns/Hiro%20pattern.pdf">Hiro pattern</a> and <a href="https://github.com/artoolkit/artoolkit5/blob/master/doc/patterns/Kanji%20pattern.pdf">Kanji pattern</a>
+			<a href="https://github.com/artoolkitx/artoolkit5/blob/master/doc/patterns/Hiro%20pattern.pdf">Hiro pattern</a> and <a href="https://github.com/artoolkitx/artoolkit5/blob/master/doc/patterns/Kanji%20pattern.pdf">Kanji pattern</a>
 		</div>
 
 		<div class="example">

--- a/examples/intro_example.html
+++ b/examples/intro_example.html
@@ -23,7 +23,7 @@ html,body {
 
 <h1>Box demo with Three.js</h1>
 <p>On Chrome on Android, tap the screen to start playing video stream.</p>
-<p>Show <a href="https://github.com/artoolkit/artoolkit5/blob/master/doc/patterns/Matrix%20code%203x3%20(72dpi)/20.png">3x3 marker id 20</a> to camera to display a box on top of it. Tap the box to open it.
+<p>Show <a href="https://github.com/artoolkitx/artoolkit5/blob/master/doc/patterns/Matrix%20code%203x3%20(72dpi)/20.png">3x3 marker id 20</a> to camera to display a box on top of it. Tap the box to open it.
 
 
 <p>&larr; <a href="index.html">Back to examples</a></p>

--- a/examples/multimarker_barcode_threejs.html
+++ b/examples/multimarker_barcode_threejs.html
@@ -23,7 +23,7 @@ html,body {
 
 <h1>Barcode multimarker example with Three.js</h1>
 <p>On Chrome on Android, tap the screen to start playing video stream.</p>
-<p>Show <a href="https://github.com/artoolkit/artoolkit5/blob/master/doc/patterns/Multi%20pattern%204x3%20(A4).pdf">Multi pattern 4x3</a> to camera to display objects on top of it.
+<p>Show <a href="https://github.com/artoolkitx/artoolkit5/blob/master/doc/patterns/Multi%20pattern%204x3%20(A4).pdf">Multi pattern 4x3</a> to camera to display objects on top of it.
 
 <p>&larr; <a href="index.html">Back to examples</a></p>
 

--- a/examples/multimarker_pattern_threejs.html
+++ b/examples/multimarker_pattern_threejs.html
@@ -23,7 +23,7 @@ html,body {
 
 <h1>Pattern multimarker example with Three.js</h1>
 <p>On Chrome on Android, tap the screen to start playing video stream.</p>
-<p>Show <a href="https://github.com/artoolkit/artoolkit5/blob/master/doc/patterns/Multi%20pattern%20(template%2C%20A4).pdf">Multi pattern (template)</a> to camera to display objects on top of it.
+<p>Show <a href="https://github.com/artoolkitx/artoolkit5/blob/master/doc/patterns/Multi%20pattern%20(template%2C%20A4).pdf">Multi pattern (template)</a> to camera to display objects on top of it.
 
 <p>&larr; <a href="index.html">Back to examples</a></p>
 

--- a/examples/nft_improved_worker/index.html
+++ b/examples/nft_improved_worker/index.html
@@ -1,13 +1,13 @@
 <html>
 <head>
-    <title>nft pages</title>
+    <title>NFT examples</title>
     <meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=0.5, maximum-scale=1">
 </head>
 
 <body>
     <link rel="stylesheet" href="../css/index.css">
-    <h3>jsartoolkit5 demos with ar2Tracking</h3>
-    <div>Image to recognize for the following examples <a href="https://imgur.com/HvcmRVl">https://imgur.com/HvcmRVl</a></div>
+    <h3>Jsartoolkit5 demos with ar2Tracking</h3>
+    <div>Image to recognize for the following examples <a href="https://github.com/artoolkitx/artoolkit5/blob/master/doc/Marker%20images/pinball.jpg">Pinball image</a></div>
     <p>Examples:</p>
     <ul>
         <li><a href="threejs_worker_gltf.html">Show a 3D, animated model. Uses web worker. Has loader. Has interpolation.</a></li>

--- a/examples/nft_improved_worker/main_threejs_wasm_worker.html
+++ b/examples/nft_improved_worker/main_threejs_wasm_worker.html
@@ -52,7 +52,7 @@
       </div>
 
       <a
-          href="https://raw.githubusercontent.com/artoolkit/artoolkit5/master/doc/Marker%20images/pinball.jpg"
+          href="https://raw.githubusercontent.com/artoolkitx/artoolkit5/master/doc/Marker%20images/pinball.jpg"
           class="ui marker"
           target="_blank">
           🖼 Marker Image

--- a/examples/nft_improved_worker/main_threejs_worker.html
+++ b/examples/nft_improved_worker/main_threejs_worker.html
@@ -52,7 +52,7 @@
       </div>
 
       <a
-          href="https://raw.githubusercontent.com/artoolkit/artoolkit5/master/doc/Marker%20images/pinball.jpg"
+          href="https://raw.githubusercontent.com/artoolkitx/artoolkit5/master/doc/Marker%20images/pinball.jpg"
           class="ui marker"
           target="_blank">
           🖼 Marker Image

--- a/examples/nft_improved_worker/threejs_worker_gltf.html
+++ b/examples/nft_improved_worker/threejs_worker_gltf.html
@@ -44,7 +44,7 @@
       <canvas id="canvas"></canvas>
     </div>
     <a
-      href="https://raw.githubusercontent.com/artoolkit/artoolkit5/master/doc/Marker%20images/pinball.jpg"
+      href="https://raw.githubusercontent.com/artoolkitx/artoolkit5/master/doc/Marker%20images/pinball.jpg"
       class="ui marker"
       target="_blank"
     >

--- a/examples/pattern_and_barcode_threejs.html
+++ b/examples/pattern_and_barcode_threejs.html
@@ -23,7 +23,7 @@ html,body {
 
 <h1>Mixed marker example with Three.js</h1>
 <p>On Chrome on Android, tap the screen to start playing video stream.</p>
-<p>Show <a href="https://github.com/artoolkit/artoolkit5/blob/master/doc/patterns/Matrix%20code%203x3%20(72dpi)/5.png">3x3 marker id 5</a>, <a href="https://github.com/artoolkit/artoolkit5/blob/master/doc/patterns/Matrix%20code%203x3%20(72dpi)/20.png">3x3 marker id 20</a>, <a href="https://github.com/artoolkit/artoolkit5/blob/master/doc/patterns/Hiro%20pattern.pdf">Hiro pattern</a> and <a href="https://github.com/artoolkit/artoolkit5/blob/master/doc/patterns/Kanji%20pattern.pdf">Kanji pattern</a> to camera to display a colorful objects on top of them. Tap the objects to spin them.
+<p>Show <a href="https://github.com/artoolkitx/artoolkit5/blob/master/doc/patterns/Matrix%20code%203x3%20(72dpi)/5.png">3x3 marker id 5</a>, <a href="https://github.com/artoolkitx/artoolkit5/blob/master/doc/patterns/Matrix%20code%203x3%20(72dpi)/20.png">3x3 marker id 20</a>, <a href="https://github.com/artoolkitx/artoolkit5/blob/master/doc/patterns/Hiro%20pattern.pdf">Hiro pattern</a> and <a href="https://github.com/artoolkitx/artoolkit5/blob/master/doc/patterns/Kanji%20pattern.pdf">Kanji pattern</a> to camera to display a colorful objects on top of them. Tap the objects to spin them.
 
 <p>&larr; <a href="index.html">Back to examples</a></p>
 

--- a/examples/pattern_threejs.html
+++ b/examples/pattern_threejs.html
@@ -23,11 +23,10 @@ html,body {
 
 <h1>Pattern marker example with Three.js</h1>
 <p>On Chrome on Android, tap the screen to start playing video stream.</p>
-<p>Show  <a href="https://github.com/artoolkit/artoolkit5/blob/master/doc/patterns/Hiro%20pattern.pdf">Hiro pattern</a> and <a href="https://github.com/artoolkit/artoolkit5/blob/master/doc/patterns/Kanji%20pattern.pdf">Kanji pattern</a> to camera to display a colorful objects on top of them. Tap the screen to rotate the objects.
+<p>Show  <a href="https://github.com/artoolkitx/artoolkit5/blob/master/doc/patterns/Hiro%20pattern.pdf">Hiro pattern</a> and <a href="https://github.com/artoolkitx/artoolkit5/blob/master/doc/patterns/Kanji%20pattern.pdf">Kanji pattern</a> to camera to display a colorful objects on top of them. Tap the screen to rotate the objects.
 
 <p>&larr; <a href="index.html">Back to examples</a></p>
 
-<!--<script async src="../build/artoolkitNft.min.js"></script>-->
 <script async src="../build/artoolkit.debug.js"></script>
 <script src="../js/artoolkit.api.js"></script>
 <script async src="js/third_party/three.js/three.min.js"></script>

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   },
   "scripts": {
     "build-local": "node tools/makem.js; echo Built at `date`",
+    "build-local-no-libar": "node tools/makem.js --no-libar; echo Built at `date`",
     "watch": "./node_modules/.bin/watch 'npm run build' ./js/",
     "create-doc": "grunt jsdoc",
     "test": "http-server -p 8085",

--- a/package.json
+++ b/package.json
@@ -1,15 +1,17 @@
 {
   "name": "jsartoolkit",
-  "version": "0.0.0",
+  "version": "5.5.139",
   "main": "js/index",
   "typings": "js/index",
   "description": "Emscripten port of ARToolKit to JavaScript",
   "keywords": [
     "ARToolKit",
     "AR",
-    "Augmented Reality"
+    "Augmented Reality",
+    "WebAR",
+    "JavaScript"
   ],
-  "author": "ARToolKit (https://github.com/artoolkit)",
+  "author": "ARToolKit (https://github.com/artoolkitx/artoolkit5)",
   "repository": "git://https://github.com/artoolkitx/jsartoolkit5.git",
   "homepage": "https://github.com/artoolkitx/jsartoolkit5",
   "contributors": [

--- a/tools/makem.js
+++ b/tools/makem.js
@@ -14,6 +14,17 @@ var
 
 const platform = os.platform();
 
+var NO_LIBAR = false;
+
+var arguments = process.argv;
+
+for (var j = 2; j < arguments.length; j++) {
+	if (arguments[j] == '--no-libar') {
+		NO_LIBAR = true;
+		console.log('Building jsartoolkit5 with --no-libar option, libar will be preserved.');
+	};
+}
+
 var HAVE_NFT = 1;
 
 var EMSCRIPTEN_ROOT = process.env.EMSCRIPTEN;
@@ -196,8 +207,12 @@ function clean_builds() {
 
     try {
         var files = fs.readdirSync(OUTPUT_PATH);
-        if (files.length > 0)
-            for (var i = 0; i < files.length; i++) {
+				var filesLength = files.length;
+        if (filesLength > 0)
+				if (NO_LIBAR == true){
+					filesLength -= 1;
+				}
+            for (var i = 0; i < filesLength; i++) {
                 var filePath = OUTPUT_PATH + '/' + files[i];
                 if (fs.statSync(filePath).isFile())
                     fs.unlinkSync(filePath);
@@ -284,5 +299,8 @@ addJob(compile_combine);
 addJob(compile_wasm);
 addJob(compile_combine_min);
 // addJob(compile_all);
+if (NO_LIBAR == true){
+	jobs.splice(1,1);
+}
 
 runJob();

--- a/tools/makem.js
+++ b/tools/makem.js
@@ -8,8 +8,8 @@
 var
 	exec = require('child_process').exec,
 	path = require('path'),
-  fs = require('fs'),
-  os = require('os'),
+	fs = require('fs'),
+	os = require('os'),
 	child;
 
 const platform = os.platform();
@@ -85,7 +85,7 @@ function matchAll(patterns, prefix="") {
     return r;
 }
 
-	ar_sources = matchAll([
+  ar_sources = matchAll([
     'AR/arLabelingSub/*.c',
     'AR/*.c',
     'ARICP/*.c',
@@ -177,10 +177,8 @@ FLAGS += ' --bind ';
 
 /* DEBUG FLAGS */
 var DEBUG_FLAGS = ' -g ';
-// DEBUG_FLAGS += ' -s ASSERTIONS=2 '
 DEBUG_FLAGS += ' -s ASSERTIONS=1 '
 DEBUG_FLAGS += ' --profiling '
-// DEBUG_FLAGS += ' -s EMTERPRETIFY_ADVISE=1 '
 DEBUG_FLAGS += ' -s ALLOW_MEMORY_GROWTH=1';
 DEBUG_FLAGS += '  -s DEMANGLE_SUPPORT=1 ';
 
@@ -248,11 +246,6 @@ var compile_wasm = format(EMCC + ' ' + INCLUDES + ' '
     + FLAGS + WASM_FLAGS + DEFINES + PRE_FLAGS + ' -o {OUTPUT_PATH}{BUILD_FILE} ',
     OUTPUT_PATH, OUTPUT_PATH, BUILD_WASM_FILE);
 
-var compile_all = format(EMCC + ' ' + INCLUDES + ' '
-    + ar_sources.join(' ')
-    + FLAGS + ' ' + DEFINES + ' -o {OUTPUT_PATH}{BUILD_FILE} ',
-    OUTPUT_PATH, BUILD_DEBUG_FILE);
-
 /*
  * Run commands
  */
@@ -293,14 +286,12 @@ function addJob(job) {
 
 addJob(clean_builds);
 addJob(compile_arlib);
-//addJob(compile_kpm);
-// compile_kpm
 addJob(compile_combine);
 addJob(compile_wasm);
 addJob(compile_combine_min);
-// addJob(compile_all);
+
 if (NO_LIBAR == true){
-	jobs.splice(1,1);
+  jobs.splice(1,1);
 }
 
 runJob();


### PR DESCRIPTION
From #44 . This PR will speed up the build process of the libs. If you have already build **libar.bc** with the command:

`npm run buil-local `

the second time run instead:

`npm run buil-local-no-libar`

libar.bc will not be build again saving time and effort.

Updated documentation and cleaned also makem.js by obsolete old part of code, fixed some lintings, and typos, in package.json and Readme.md.

Tested under linux OS (Ubuntu 18.04.03 LTS)